### PR TITLE
Alternatively pull thumbnail from postmeta other than _thumbnail_id

### DIFF
--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -270,14 +270,14 @@ class Plugin {
 			}
 		}
 
-		$include_featured_images = ! empty( $post_query_args['include_featured_images'] );
+		$include_featured_images = empty( $post_query_args['include_featured_images'] ) ? false : $post_query_args['include_featured_images'];
 
 		$query = new \WP_Query( array_merge(
 			array(
 				'post_status' => 'publish',
 				'post_type' => array( 'post' ),
 				'ignore_sticky_posts' => true,
-				'update_post_meta_cache' => $include_featured_images,
+				'update_post_meta_cache' => ( false !== $include_featured_images ),
 				'update_post_term_cache' => false,
 				'no_found_rows' => false,
 			),
@@ -313,7 +313,7 @@ class Plugin {
 					'post_author' => $post->post_author,
 				);
 				if ( $include_featured_images ) {
-					$attachment_id = get_post_thumbnail_id( $post->ID );
+					$attachment_id = get_post_meta( $post->ID, $include_featured_images, true ) ?: get_post_thumbnail_id( $post->ID );
 					if ( $attachment_id ) {
 						$result['featured_image'] = wp_prepare_attachment_for_js( $attachment_id );
 					} else {

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -314,6 +314,15 @@ class Plugin {
 				);
 				if ( $include_featured_images ) {
 					$attachment_id = get_post_thumbnail_id( $post->ID );
+
+					/**
+					 * Filters the attachment ID for the featured image for a given post.
+					 *
+					 * @param int|bool $attachment_id Attachment ID or `false` if no featured image is associated.
+					 * @param \WP_Post $post Post.
+					 */
+					$attachment_id = apply_filters( 'customize_object_selector_featured_image', $attachment_id, $post );
+
 					if ( $attachment_id ) {
 						$result['featured_image'] = wp_prepare_attachment_for_js( $attachment_id );
 					} else {

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -270,14 +270,14 @@ class Plugin {
 			}
 		}
 
-		$include_featured_images = empty( $post_query_args['include_featured_images'] ) ? false : $post_query_args['include_featured_images'];
+		$include_featured_images = ! empty( $post_query_args['include_featured_images'] );
 
 		$query = new \WP_Query( array_merge(
 			array(
 				'post_status' => 'publish',
 				'post_type' => array( 'post' ),
 				'ignore_sticky_posts' => true,
-				'update_post_meta_cache' => ( false !== $include_featured_images ),
+				'update_post_meta_cache' => $include_featured_images,
 				'update_post_term_cache' => false,
 				'no_found_rows' => false,
 			),
@@ -313,7 +313,7 @@ class Plugin {
 					'post_author' => $post->post_author,
 				);
 				if ( $include_featured_images ) {
-					$attachment_id = get_post_meta( $post->ID, $include_featured_images, true ) ?: get_post_thumbnail_id( $post->ID );
+					$attachment_id = get_post_thumbnail_id( $post->ID );
 					if ( $attachment_id ) {
 						$result['featured_image'] = wp_prepare_attachment_for_js( $attachment_id );
 					} else {


### PR DESCRIPTION
With this change, we will be able to specify which post meta field to look at to find the attachment id we want to use for the thumbnail. It will still default to the post thumbnail.

Since this is no longer a simple boolean, it might make sense to change the name of the post_query_arg, but that is a potentially breaking change, so I am asking first.

Should I change the name from include_featured_images to use_attachment_as_thumbnail or something else?
