### PR TITLE
Add support for emulating wp_dropdown_pages() when the post type is hierarchichal

### DIFF
--- a/js/customize-object-selector-component.js
+++ b/js/customize-object-selector-component.js
@@ -1,12 +1,18 @@
 /* global JSON */
 /* eslint consistent-this: [ "error", "component" ] */
 /* eslint no-magic-numbers: ["error", { "ignore": [-1,0,1] }] */
-/* eslint complexity: ["error", 10] */
+/* eslint complexity: ["error", 11] */
 
 wp.customize.ObjectSelectorComponent = (function( api, $ ) {
 	'use strict';
 
 	return api.Class.extend({
+
+		// Note the translations are exported from PHP via \CustomizeObjectSelector\Plugin::register_scripts().
+		l10n: {
+			missing_model_arg: '',
+			failed_to_fetch_selections: ''
+		},
 
 		/**
 		 * Initialize.
@@ -28,7 +34,7 @@ wp.customize.ObjectSelectorComponent = (function( api, $ ) {
 			var component = this;
 
 			if ( ! args.model || 'function' !== typeof args.model.get ) {
-				throw new Error( 'Missing valid model arg.' );
+				throw new Error( component.l10n.missing_model_arg );
 			}
 			component.model = args.model;
 			component.containing_construct = args.containing_construct || null;
@@ -129,7 +135,7 @@ wp.customize.ObjectSelectorComponent = (function( api, $ ) {
 
 			// Sync the setting values with the select2 values.
 			component.model.bind( function() {
-				component.populateSelectOptions();
+				component.populateSelectOptions( false );
 			} );
 
 			component.setupSortable();
@@ -547,7 +553,7 @@ wp.customize.ObjectSelectorComponent = (function( api, $ ) {
 						// @todo The error should be triggered on the component itself so that the control adds it to its notifications. Too much coupling here.
 						notification = new api.Notification( 'select2_init_failure', {
 							type: 'error',
-							message: 'Failed to fetch selections.' // @todo l10n
+							message: component.l10n.failed_to_fetch_selections.replace( '%s', statusText )
 						} );
 						component.containing_construct.notifications.add( notification.code, notification );
 					}

--- a/js/customize-object-selector-component.js
+++ b/js/customize-object-selector-component.js
@@ -83,7 +83,15 @@ wp.customize.ObjectSelectorComponent = (function( api, $ ) {
 								paged: params.data.page || 1
 							});
 							request.done( success );
-							request.fail( failure );
+							request.fail( function( jqXHR, status ) {
+
+								// Inform select2 of aborts. See <https://github.com/select2/select2/blob/062c6c3af5f0f39794c34c0a343a3857e587cc97/src/js/select2/data/ajax.js#L83-L87>.
+								if ( 'abort' === status ) {
+									request.status = '0';
+								}
+
+								failure.apply( request, arguments );
+							} );
 							return request;
 						}
 					},

--- a/js/customize-object-selector-component.js
+++ b/js/customize-object-selector-component.js
@@ -20,7 +20,8 @@ wp.customize.ObjectSelectorComponent = (function( api, $ ) {
 		 * @param {object}   args.select2_options - See available options at https://select2.github.io/examples.html#programmatic-control
 		 * @param {boolean}  args.select2_options.multiple - Whether multiple can be selected.
 		 * @param {string}   args.select_id - ID to be used for the underlying select element
-		 * @param {object}   args.post_query_vars - WP_Query vars to use in the query, opon which 's' and 'paged' will be merged.
+		 * @param {object}   args.post_query_vars - WP_Query vars to use in the query, upon which 's' and 'paged' will be merged.
+		 * @param {Boolean}  args.show_add_buttons - Whether add buttons will be shown if available.
 		 * @returns {void}
 		 */
 		initialize: function initialize( args ) {
@@ -41,6 +42,7 @@ wp.customize.ObjectSelectorComponent = (function( api, $ ) {
 			}
 			component.container = args.container;
 			component.post_query_vars = null;
+			component.show_add_buttons = _.isUndefined( args.show_add_buttons ) ? true : args.show_add_buttons;
 			component.select_id = args.select_id || '';
 			component.control_template = args.control_template || wp.template( 'customize-object-selector-component' );
 			component.select2_result_template = args.select2_result_template || wp.template( 'customize-object-selector-item' );
@@ -66,7 +68,7 @@ wp.customize.ObjectSelectorComponent = (function( api, $ ) {
 			templateData = {
 				multiple: component.multiple,
 				select_id: component.select_id,
-				addable_post_types: component.getAddableQueriedPostTypes()
+				addable_post_types: component.show_add_buttons ? component.getAddableQueriedPostTypes() : []
 			};
 
 			component.container.empty().append( component.control_template( templateData ) );

--- a/js/customize-object-selector-control.js
+++ b/js/customize-object-selector-control.js
@@ -132,6 +132,7 @@
 				model: model,
 				containing_construct: control,
 				post_query_vars: control.params.post_query_vars,
+				show_add_buttons: control.params.show_add_buttons,
 				select_id: control.params.select_id,
 				select2_options: control.params.select2_options,
 				select2_result_template: itemTemplate,

--- a/php/class-control.php
+++ b/php/class-control.php
@@ -41,6 +41,15 @@ class Control extends \WP_Customize_Control {
 	public $post_query_vars;
 
 	/**
+	 * Whether the add buttons will be shown.
+	 *
+	 * These buttons will only appear if the Customize Posts plugin is active.
+	 *
+	 * @var bool
+	 */
+	public $show_add_buttons = true;
+
+	/**
 	 * Setting property.
 	 *
 	 * If defined, the associated setting is assumed to be an object (e.g. a post)
@@ -96,6 +105,7 @@ class Control extends \WP_Customize_Control {
 				'select2_options',
 				'post_query_vars',
 				'setting_property',
+				'show_add_buttons',
 			) )
 		);
 	}

--- a/php/class-control.php
+++ b/php/class-control.php
@@ -34,11 +34,11 @@ class Control extends \WP_Customize_Control {
 	);
 
 	/**
-	 * Query args for posts.
+	 * Query vars for posts.
 	 *
 	 * @var array|null
 	 */
-	public $post_query_args;
+	public $post_query_vars;
 
 	/**
 	 * Setting property.
@@ -94,7 +94,7 @@ class Control extends \WP_Customize_Control {
 			parent::json(),
 			wp_array_slice_assoc( get_object_vars( $this ), array(
 				'select2_options',
-				'post_query_args',
+				'post_query_vars',
 				'setting_property',
 			) )
 		);

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -91,6 +91,9 @@ class Plugin {
 					),
 				) );
 
+				// Make sure the value is exported to JS as an integer.
+				add_filter( "customize_sanitize_js_{$selector_control->setting->id}", 'absint' );
+
 				$wp_customize->remove_control( $existing_control->id );
 				$wp_customize->add_control( $selector_control );
 			}

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -202,9 +202,6 @@ class Plugin {
 			),
 			$post_query_vars
 		);
-		if ( ! empty( $post_query_vars['post__in'] ) ) {
-			$post_query_vars['posts_per_page'] = -1;
-		}
 
 		// Whitelist allowed query vars.
 		$allowed_query_vars = array(
@@ -338,6 +335,9 @@ class Plugin {
 		}
 
 		$post_query_vars['include_featured_images'] = ! empty( $post_query_args['include_featured_images'] );
+		if ( ! empty( $post_query_vars['post__in'] ) ) {
+			$post_query_vars['posts_per_page'] = -1;
+		}
 
 		if ( ! is_array( $post_query_vars['tree_args'] ) ) {
 			return new \WP_Error(

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -124,6 +124,17 @@ class Plugin {
 		$in_footer = 1;
 		$wp_scripts->add( $handle, $src, $deps, $this->version, $in_footer );
 
+		$l10n = array(
+			'missing_model_arg' => __( 'Missing valid model arg.', 'customize-object-selector' ),
+			/* translators: %s is the status text */
+			'failed_to_fetch_selections' => __( 'Failed to fetch selections: %s', 'customize-object-selector' ),
+		);
+		$wp_scripts->add_inline_script(
+			$handle,
+			sprintf( 'wp.customize.ObjectSelectorComponent.prototype.l10n = %s;', wp_json_encode( $l10n ) ),
+			'after'
+		);
+
 		$handle = 'customize-object-selector-control';
 		$src = plugins_url( 'js/customize-object-selector-control' . $suffix, __DIR__ );
 		$deps = array( 'customize-controls', 'customize-object-selector-component' );

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -78,6 +78,7 @@ class Plugin {
 					'post_query_vars' => array(
 						'post_type' => 'page',
 						'post_status' => 'publish',
+						'show_initial_dropdown' => true,
 						'dropdown_args' => array(
 							'sort_column' => 'menu_order, post_title',
 						),
@@ -210,7 +211,7 @@ class Plugin {
 			}
 		}
 
-		if ( '' === trim( $post_query_args['s'] ) && isset( $post_query_args['dropdown_args'] ) ) {
+		if ( '' === trim( $post_query_args['s'] ) && ! empty( $post_query_args['show_initial_dropdown'] ) ) {
 			$results = $this->build_post_dropdown( $post_query_args );
 		} else {
 			$results = $this->query_posts( $post_query_args );
@@ -240,6 +241,7 @@ class Plugin {
 			array(
 				's' => '',
 				'paged' => 1,
+				'show_initial_dropdown' => false,
 				'dropdown_args' => array(),
 			),
 			$post_query_vars
@@ -248,6 +250,7 @@ class Plugin {
 		// Whitelist allowed query vars.
 		$allowed_query_vars = array(
 			'include_featured_images',
+			'show_initial_dropdown',
 			'dropdown_args',
 			'apply_dropdown_args_filters_post_id',
 			'post_status',
@@ -381,6 +384,8 @@ class Plugin {
 		if ( ! empty( $post_query_vars['post__in'] ) ) {
 			$post_query_vars['posts_per_page'] = -1;
 		}
+
+		$post_query_vars['show_initial_dropdown'] = ! empty( $post_query_vars['show_initial_dropdown'] );
 
 		if ( ! is_array( $post_query_vars['dropdown_args'] ) ) {
 			return new \WP_Error(

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -125,21 +125,91 @@ class Plugin {
 	 */
 	public function handle_ajax_object_selector_query() {
 		global $wp_customize;
+
+		// Close output buffering to ensure that _ajax_wp_die_handler doesn't clobber the status_header(). See <https://core.trac.wordpress.org/ticket/35666#comment:6>.
+		while ( 0 !== ob_get_level()  ) {
+			ob_end_clean();
+		}
+
 		$nonce_query_var_name = 'customize_object_selector_query_nonce';
 		if ( ! check_ajax_referer( static::OBJECT_SELECTOR_QUERY_AJAX_ACTION, $nonce_query_var_name, false ) ) {
-			wp_send_json_error( array( 'code' => 'bad_nonce' ) );
+			status_header( 400 );
+			wp_send_json_error( array( 'code' => 'bad_nonce' ), 400 ); // Note: The redundant 400 status is needed until #35666 is resolved.
 		}
 		if ( ! isset( $_POST['post_query_args'] ) ) {
-			wp_send_json_error( array( 'code' => 'missing_post_query_args' ) );
+			status_header( 400 );
+			wp_send_json_error( array( 'code' => 'missing_post_query_args' ), 400 );
 		}
 		$post_query_args = json_decode( wp_unslash( $_POST['post_query_args'] ), true );
 		if ( ! is_array( $post_query_args ) ) {
-			wp_send_json_error( array( 'code' => 'invalid_post_query_args' ) );
+			status_header( 400 );
+			wp_send_json_error( array( 'code' => 'invalid_post_query_args' ), 400 );
+		}
+
+		$post_query_args = $this->process_post_query_vars( $post_query_args );
+		if ( is_wp_error( $post_query_args ) ) {
+			status_header( 400 );
+			wp_send_json_error( array(
+				'code' => $post_query_args->get_error_code(),
+				'message' => $post_query_args->get_error_message(),
+				'data' => $post_query_args->get_error_data(),
+			), 400 );
+		}
+
+		// Make sure that the Customizer state is applied in any query results (especially via the Customize Posts plugin).
+		if ( ! empty( $wp_customize ) ) {
+			foreach ( $wp_customize->settings() as $setting ) {
+				/**
+				 * Setting.
+				 *
+				 * @var \WP_Customize_Setting $setting
+				 */
+				$setting->preview();
+			}
+		}
+
+		if ( '' === trim( $post_query_args['s'] ) && ! empty( $post_query_args['tree_args'] ) ) {
+			$results = $this->build_post_tree( $post_query_args );
+		} else {
+			$results = $this->query_posts( $post_query_args );
+		}
+		if ( is_wp_error( $results ) ) {
+			status_header( 400 );
+			wp_send_json_error( array(
+				'code' => $results->get_error_code(),
+				'message' => $results->get_error_message(),
+				'data' => $results->get_error_data(),
+			), 400 );
+		} else {
+			wp_send_json_success( $results );
+		}
+	}
+
+	/**
+	 * Process post query vars (i.e. WP_Query vars).
+	 *
+	 * @param array $post_query_vars Post query vars.
+	 *
+	 * @return array|\WP_Error Processed post query vars or WP_Error on error.
+	 */
+	public function process_post_query_vars( $post_query_vars ) {
+
+		$post_query_vars = array_merge(
+			array(
+				's' => '',
+				'paged' => 1,
+				'tree_args' => array(),
+			),
+			$post_query_vars
+		);
+		if ( ! empty( $post_query_vars['post__in'] ) ) {
+			$post_query_vars['posts_per_page'] = -1;
 		}
 
 		// Whitelist allowed query vars.
 		$allowed_query_vars = array(
 			'include_featured_images',
+			'tree_args',
 			'post_status',
 			'post_type',
 			's',
@@ -164,71 +234,70 @@ class Plugin {
 		// White list allowed meta query compare values.
 		$allowed_meta_query_compare_values = array( '=', '!=', '>', '>=', '<', '<=' );
 
-		$extra_query_vars = array_diff( array_keys( $post_query_args ), $allowed_query_vars );
+		$extra_query_vars = array_diff( array_keys( $post_query_vars ), $allowed_query_vars );
 		if ( ! empty( $extra_query_vars ) ) {
-			wp_send_json_error( array(
-				'code' => 'disallowed_query_var',
-				'query_vars' => array_values( $extra_query_vars ),
-			) );
+			return new \WP_Error(
+				'disallowed_query_var',
+				__( 'Disallowed query var', 'customize-object-selector' ),
+				array( 'query_vars' => array_values( $extra_query_vars ) )
+			);
 		}
-		if ( ! empty( $post_query_args['meta_compare'] ) && ! in_array( $post_query_args['meta_compare'], $allowed_meta_query_compare_values, true ) ) {
-			wp_send_json_error( array(
-				'code' => 'disallowed_meta_compare_query_var',
-				'query_vars' => $post_query_args['meta_compare'],
-			) );
+		if ( ! empty( $post_query_vars['meta_compare'] ) && ! in_array( $post_query_vars['meta_compare'], $allowed_meta_query_compare_values, true ) ) {
+			return new \WP_Error(
+				'disallowed_meta_compare_query_var',
+				__( 'Disallowed meta_compare query var', 'customize-object-selector' ),
+				array( 'query_var' => $post_query_vars['meta_compare'] )
+			);
 		}
 
 		// Currently this does not support nested meta_query.
-		if ( isset( $post_query_args['meta_query'] ) && ! empty( $post_query_args['meta_query'] ) ) {
-			foreach ( $post_query_args['meta_query'] as $key => $val ) {
+		if ( isset( $post_query_vars['meta_query'] ) && ! empty( $post_query_vars['meta_query'] ) ) {
+			foreach ( $post_query_vars['meta_query'] as $key => $val ) {
 				if ( 'relation' === $key ) {
 					if ( 'AND' !== $val ) {
-						wp_send_json_error( array(
-							'code'       => 'disallowed_meta_query_relation_var',
-							'query_vars' => array_values( $val ),
-						) );
+						return new \WP_Error(
+							'disallowed_meta_query_relation_var',
+							__( 'Disallowed meta_query relation', 'customize-object-selector' ),
+							array( 'query_vars' => array_values( $val ) )
+						);
 					}
 					continue;
 				}
 				$extra_meta_query_vars = array_diff( array_keys( $val ), $allowed_meta_query_vars );
 				if ( ! empty( $extra_meta_query_vars ) ) {
-					wp_send_json_error( array(
-						'code'       => 'disallowed_meta_query_var',
-						'query_vars' => array_values( $extra_meta_query_vars ),
-					) );
+					return new \WP_Error(
+						'disallowed_meta_query_var',
+						__( 'Disallowed meta_query var', 'customize-object-selector' ),
+						array( 'query_vars' => array_values( $extra_meta_query_vars ) )
+					);
 				}
 				if ( ! empty( $val['compare'] ) && ! in_array( $val['compare'], $allowed_meta_query_compare_values, true ) ) {
-					wp_send_json_error( array(
-						'code'       => 'disallowed_meta_compare_query_var',
-						'query_vars' => $post_query_args['meta_query']['compare'],
-					) );
+					return new \WP_Error(
+						'disallowed_meta_compare_query_var',
+						__( 'Disallowed meta_compare query var', 'customize-object-selector' ),
+						array( 'query_vars' => $post_query_vars['meta_query']['compare'] )
+					);
 				}
 			}
 		}
 
-		if ( empty( $post_query_args['paged'] ) ) {
-			$post_query_args['paged'] = 1;
-		}
-		if ( ! empty( $post_query_args['post__in'] ) ) {
-			$post_query_args['posts_per_page'] = -1;
-		}
-
 		// Get the queried post statuses and determine if if any of them are for a non-publicly queryable status.
 		$has_private_status = false;
-		if ( empty( $post_query_args['post_status'] ) ) {
-			$post_query_args['post_status'] = array( 'publish' );
-		} elseif ( is_string( $post_query_args['post_status'] ) ) {
-			$post_query_args['post_status'] = explode( ',', $post_query_args['post_status'] );
+		if ( empty( $post_query_vars['post_status'] ) ) {
+			$post_query_vars['post_status'] = array( 'publish' );
+		} elseif ( is_string( $post_query_vars['post_status'] ) ) {
+			$post_query_vars['post_status'] = explode( ',', $post_query_vars['post_status'] );
 		} else {
-			$post_query_args['post_status'] = (array) $post_query_args['post_status'];
+			$post_query_vars['post_status'] = (array) $post_query_vars['post_status'];
 		}
-		foreach ( $post_query_args['post_status'] as $post_status ) {
+		foreach ( $post_query_vars['post_status'] as $post_status ) {
 			$post_status_object = get_post_status_object( $post_status );
 			if ( ! $post_status_object ) {
-				wp_send_json_error( array(
-					'code' => 'bad_post_status',
-					'post_status' => $post_status,
-				) );
+				return new \WP_Error(
+					'bad_post_status',
+					__( 'Bad post status', 'customize-object-selector' ),
+					array( 'post_status' => $post_status )
+				);
 			}
 			if ( ! empty( $post_status_object->publicly_queryable ) ) {
 				$has_private_status = true;
@@ -236,55 +305,155 @@ class Plugin {
 		}
 
 		// Get the queried post types and determine if any of them are not allowed to be queried.
-		if ( empty( $post_query_args['post_type'] ) ) {
-			$post_query_args['post_type'] = array( 'post' );
-		} elseif ( is_string( $post_query_args['post_type'] ) ) {
-			$post_query_args['post_type'] = explode( ',', $post_query_args['post_type'] );
+		if ( empty( $post_query_vars['post_type'] ) ) {
+			$post_query_vars['post_type'] = array( 'post' );
+		} elseif ( is_string( $post_query_vars['post_type'] ) ) {
+			$post_query_vars['post_type'] = explode( ',', $post_query_vars['post_type'] );
 		} else {
-			$post_query_args['post_type'] = (array) $post_query_args['post_type'];
+			$post_query_vars['post_type'] = (array) $post_query_vars['post_type'];
 		}
-		foreach ( $post_query_args['post_type'] as $post_type ) {
+		foreach ( $post_query_vars['post_type'] as $post_type ) {
 			$post_type_object = get_post_type_object( $post_type );
 			if ( ! $post_type_object ) {
-				wp_send_json_error( array(
-					'code' => 'bad_post_type',
-					'post_type' => $post_type,
-				) );
+				return new \WP_Error(
+					'bad_post_type',
+					__( 'Bad post type', 'customize-object-selector' ),
+					array( 'post_type' => $post_type )
+				);
 			}
 			if ( ! current_user_can( $post_type_object->cap->read ) ) {
-				wp_send_json_error( array(
-					'code' => 'cannot_query_posts',
-					'post_type' => $post_type,
-				) );
+				return new \WP_Error(
+					'cannot_query_posts',
+					__( 'Cannot query posts', 'customize-object-selector' ),
+					array( 'post_type' => $post_type )
+				);
 			}
 			if ( $has_private_status && ! current_user_can( $post_type_object->cap->read_private_posts ) ) {
-				wp_send_json_error( array(
-					'code' => 'cannot_query_private_posts',
-					'post_type' => $post_type,
-				) );
+				return new \WP_Error(
+					'cannot_query_private_posts',
+					__( 'Cannot query private posts', 'customize-object-selector' ),
+					array( 'post_type' => $post_type )
+				);
 			}
 		}
 
-		// Make sure that the Customizer state is applied in any query results (especially via the Customize Posts plugin).
-		if ( ! empty( $wp_customize ) ) {
-			foreach ( $wp_customize->settings() as $setting ) {
-				/**
-				 * Setting.
-				 *
-				 * @var \WP_Customize_Setting $setting
-				 */
-				$setting->preview();
+		$post_query_vars['include_featured_images'] = ! empty( $post_query_args['include_featured_images'] );
+
+		if ( ! is_array( $post_query_vars['tree_args'] ) ) {
+			return new \WP_Error(
+				'bad_tree_args',
+				__( 'Expected tree_args as array', 'customize-object-selector' )
+			);
+		}
+
+		// See wp_dropdown_pages(), get_pages(), walk_page_dropdown_tree(), and the page_attributes_dropdown_pages_args filter.
+		$allowed_args = array(
+			'exclude_tree',
+			'sort_column',
+			// @todo Support more args as they are supported by Customize Posts for get_pages().
+		);
+		foreach ( array_keys( $post_query_vars['tree_args'] ) as $key ) {
+			if ( ! in_array( $key, $allowed_args, true ) ) {
+				return new \WP_Error(
+					'unsupported_tree_arg',
+					sprintf( __( 'Unsupported arg "%s" in tree_args', 'customize-object-selector' ), $key ),
+					array( 'arg' => $key )
+				);
 			}
 		}
 
-		$include_featured_images = ! empty( $post_query_args['include_featured_images'] );
+		return $post_query_vars;
+	}
 
+	/**
+	 * Build post tree results.
+	 *
+	 * @param array $post_query_args Post query args.
+	 *
+	 * @return array|\WP_Error Response data or WP_Error if error.
+	 */
+	public function build_post_tree( $post_query_args ) {
+
+		if ( count( $post_query_args['post_type'] ) !== 1 ) {
+			return new \WP_Error(
+				'cannot_show_tree_for_multiple_post_types',
+				__( 'Cannot show tree for multiple post types', 'customize-object-selector' )
+			);
+		}
+		$post_type = $post_query_args['post_type'][0];
+		if ( ! post_type_exists( $post_type ) ) {
+			return new \WP_Error(
+				'unrecognized_post_type',
+				__( 'Unrecognized post type', 'customize-object-selector' )
+			);
+		}
+		$post_type_object = get_post_type_object( $post_type );
+		if ( ! $post_type_object->hierarchical ) {
+			return new \WP_Error(
+				'cannot_show_tree_for_non_hierarchical_post_type',
+				__( 'Cannot show tree for non-hierarchical post type', 'customize-object-selector' )
+			);
+		}
+
+		require_once __DIR__ . '/class-post-tree-walker.php';
+		$walker = new Post_Tree_Walker();
+
+		// @todo Add support for applying page_attributes_dropdown_pages_args filters if requested.
+		$tree_args = array_merge(
+			$post_query_args['tree_args'],
+			array(
+				'post_type' => $post_query_args['post_type'][0],
+				'depth' => 0,
+				'walker' => $walker,
+			)
+		);
+		$posts = get_pages( $tree_args );
+		walk_page_dropdown_tree( $posts, $tree_args['depth'], $tree_args );
+
+		$results = array();
+		foreach ( $walker->items as $item ) {
+			$post = $item['post'];
+			$title = htmlspecialchars_decode( html_entity_decode( $post->post_title ), ENT_QUOTES );
+			$post_status_obj = get_post_status_object( $post->post_status );
+			$is_publish_status = ( 'publish' === $post->post_status );
+
+			$text = '';
+			if ( ! $is_publish_status && $post_status_obj ) {
+				/* translators: 1: post status */
+				$text .= sprintf( __( '[%1$s] ', 'customize-object-selector' ), $post_status_obj->label );
+			}
+			$text .= $title;
+			$results[] = array(
+				'id' => $post->ID,
+				'text' => $text,
+				'depth' => $item['depth'],
+				'title' => $title, // Option tooltip.
+				'post_title' => $title,
+				'post_type' => $post->post_type,
+				'post_status' => $post->post_status,
+				'post_date_gmt' => $post->post_date_gmt,
+				'post_author' => $post->post_author,
+			);
+		}
+
+		return array(
+			'results' => $results,
+		);
+	}
+
+	/**
+	 * Query posts.
+	 *
+	 * @param array $post_query_args Post query vars.
+	 * @return array Success results.
+	 */
+	public function query_posts( $post_query_args ) {
 		$query = new \WP_Query( array_merge(
 			array(
 				'post_status' => 'publish',
 				'post_type' => array( 'post' ),
 				'ignore_sticky_posts' => true,
-				'update_post_meta_cache' => $include_featured_images,
+				'update_post_meta_cache' => $post_query_args['include_featured_images'],
 				'update_post_term_cache' => false,
 				'no_found_rows' => false,
 			),
@@ -294,7 +463,7 @@ class Plugin {
 		$is_multiple_post_types = count( $query->get( 'post_type' ) ) > 1;
 
 		$results = array_map(
-			function( $post ) use ( $is_multiple_post_types, $include_featured_images ) {
+			function( $post ) use ( $is_multiple_post_types, $post_query_args ) {
 				$title = htmlspecialchars_decode( html_entity_decode( $post->post_title ), ENT_QUOTES );
 				$post_type_obj = get_post_type_object( $post->post_type );
 				$post_status_obj = get_post_status_object( $post->post_status );
@@ -320,7 +489,7 @@ class Plugin {
 					'post_date_gmt' => $post->post_date_gmt,
 					'post_author' => $post->post_author,
 				);
-				if ( $include_featured_images ) {
+				if ( $post_query_args['include_featured_images'] ) {
 					$attachment_id = get_post_thumbnail_id( $post->ID );
 
 					/**
@@ -342,12 +511,12 @@ class Plugin {
 			$query->posts
 		);
 
-		wp_send_json_success( array(
+		return array(
 			'results' => $results,
 			'pagination' => array(
 				'more' => $post_query_args['paged'] < $query->max_num_pages,
 			),
-		) );
+		);
 	}
 
 	/**
@@ -392,6 +561,17 @@ class Plugin {
 					{{{ data.text }}}
 				</span>
 			<# } else { #>
+				<# if ( data.depth ) { #>
+					<#
+					var i;
+					data.indentation = '';
+					for ( i = 0; i < data.depth; i += 1 ) {
+						data.indentation += '&nbsp;&nbsp;&nbsp;';
+					}
+					#>
+					{{{ data.indentation }}}
+				<# } #>
+
 				{{{ data.text }}}
 			<# } #>
 		</script>

--- a/php/class-post-tree-walker.php
+++ b/php/class-post-tree-walker.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Post_Tree_Walker Class
+ *
+ * @package CustomizeObjectSelector
+ */
+
+namespace CustomizeObjectSelector;
+
+/**
+ * Class Post_Tree_Walker
+ */
+class Post_Tree_Walker extends \Walker_PageDropdown {
+
+	/**
+	 * Walked items in list.
+	 *
+	 * @var array
+	 */
+	public $items = array();
+
+	/**
+	 * Start the element output.
+	 *
+	 * @param string $output            Passed by reference. Used to append additional content.
+	 * @param object $post              The data object.
+	 * @param int    $depth             Depth of the item.
+	 * @param array  $args              An array of additional arguments.
+	 * @param int    $current_object_id ID of the current item.
+	 */
+	public function start_el( &$output, $post, $depth = 0, $args = array(), $current_object_id = 0 ) {
+		unset( $args, $current_object_id );
+		$this->items[] = array(
+			'post' => $post,
+			'depth' => $depth,
+		);
+		$output .= '';
+	}
+}

--- a/readme.md
+++ b/readme.md
@@ -4,9 +4,9 @@
 Adds a Customizer control to select one or multiple posts (and eventually terms and users).
 
 **Contributors:** [xwp](https://profiles.wordpress.org/xwp), [westonruter](https://profiles.wordpress.org/westonruter)  
-**Tags:** [customizer](https://wordpress.org/plugins/tags/customizer), [customize](https://wordpress.org/plugins/tags/customize), [select2](https://wordpress.org/plugins/tags/select2)  
+**Tags:** [customizer](https://wordpress.org/plugins/tags/customizer), [customize](https://wordpress.org/plugins/tags/customize), [select2](https://wordpress.org/plugins/tags/select2), [posts](https://wordpress.org/plugins/tags/posts), [pages](https://wordpress.org/plugins/tags/pages), [dropdown](https://wordpress.org/plugins/tags/dropdown)  
 **Requires at least:** 4.5  
-**Tested up to:** 4.6  
+**Tested up to:** 4.6.1  
 **Stable tag:** 0.2.0  
 **License:** [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)  
 
@@ -16,9 +16,11 @@ Adds a Customizer control to select one or multiple posts (and eventually terms 
 
 This plugin adds a Customizer control to select one or multiple posts (and eventually terms and users).
 
-When the [Customize Posts](https://github.com/xwp/wp-customize-posts) plugin is active, buttons will appear after the Select2 control to be able to create new posts to add to the selection.
+Core has long had a `dropdown-pages` control type which is used in the static front page section for the “page on front” and “page for posts” controls. There is a problem with this control however: it outputs the entire tree of pages for every registered instance of the control. For sites that have a lot of pages, this can introduce a performance problem to generate this full list, not only once, but twice for the two controls. This plugin upgrades the “page on front” and “page for posts” controls to instead make use of the Customize Object Selector control, not only allowing for the list of pages to be loaded via Ajax on demand but also for the list to be _searched_.
 
-Includes a reusable JavaScript component available at `wp.customize.ObjectSelectorComponent` which can be used in widgets or other locations.
+When the [Customize Posts](https://github.com/xwp/wp-customize-posts) plugin is active, buttons will appear after the Select2 control to be able to create new posts to add to the selection. The Customize Object Selector will also power the post parent control. See [wp-customize-posts#233](https://github.com/xwp/wp-customize-posts/pull/233).
+
+This plugin also includes a reusable JavaScript component available at `wp.customize.ObjectSelectorComponent` which can be used in widgets or other locations.
 
 For an example integration with widgets, see the [Post Collection widget](https://github.com/xwp/wp-js-widgets/pull/10).
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Customize Object Selector ===
 Contributors:      xwp, westonruter
-Tags:              customizer, customize, select2
+Tags:              customizer, customize, select2, posts, pages, dropdown
 Requires at least: 4.5
-Tested up to:      4.6
+Tested up to:      4.6.1
 Stable tag:        0.2.0
 License:           GPLv2 or later
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html
@@ -13,9 +13,11 @@ Adds a Customizer control to select one or multiple posts (and eventually terms 
 
 This plugin adds a Customizer control to select one or multiple posts (and eventually terms and users).
 
-When the [Customize Posts](https://github.com/xwp/wp-customize-posts) plugin is active, buttons will appear after the Select2 control to be able to create new posts to add to the selection.
+Core has long had a `dropdown-pages` control type which is used in the static front page section for the “page on front” and “page for posts” controls. There is a problem with this control however: it outputs the entire tree of pages for every registered instance of the control. For sites that have a lot of pages, this can introduce a performance problem to generate this full list, not only once, but twice for the two controls. This plugin upgrades the “page on front” and “page for posts” controls to instead make use of the Customize Object Selector control, not only allowing for the list of pages to be loaded via Ajax on demand but also for the list to be _searched_.
 
-Includes a reusable JavaScript component available at `wp.customize.ObjectSelectorComponent` which can be used in widgets or other locations.
+When the [Customize Posts](https://github.com/xwp/wp-customize-posts) plugin is active, buttons will appear after the Select2 control to be able to create new posts to add to the selection. The Customize Object Selector will also power the post parent control. See [wp-customize-posts#233](https://github.com/xwp/wp-customize-posts/pull/233).
+
+This plugin also includes a reusable JavaScript component available at `wp.customize.ObjectSelectorComponent` which can be used in widgets or other locations.
 
 For an example integration with widgets, see the [Post Collection widget](https://github.com/xwp/wp-js-widgets/pull/10).
 


### PR DESCRIPTION
This is a drop-in replacement/upgrade of the `dropdown-pages` control in core.

Dependency for https://github.com/xwp/wp-customize-posts/pull/233
