### PR TITLE
Ensure page for posts and page on front are not set to the same page

### DIFF
--- a/js/customize-object-selector-component.js
+++ b/js/customize-object-selector-component.js
@@ -44,7 +44,7 @@ wp.customize.ObjectSelectorComponent = (function( api, $ ) {
 				multiple: false
 			};
 			if ( args.select2_options ) {
-				_.extend( component.select2_options, args.select2_options );
+				component.select2_options = args.select2_options;
 			}
 			component.container = args.container;
 			component.post_query_vars = null;
@@ -55,8 +55,7 @@ wp.customize.ObjectSelectorComponent = (function( api, $ ) {
 			component.select2_selection_template = args.select2_selection_template || wp.template( 'customize-object-selector-item' );
 
 			if ( args.post_query_vars ) {
-				component.post_query_vars = {};
-				_.extend( component.post_query_vars, args.post_query_vars );
+				component.post_query_vars = args.post_query_vars;
 			}
 		},
 

--- a/js/customize-object-selector-static-front-page.js
+++ b/js/customize-object-selector-static-front-page.js
@@ -1,0 +1,45 @@
+/* eslint complexity: ["error", 4] */
+
+(function( api ) {
+	'use strict';
+
+	api( 'page_for_posts', 'page_on_front', function() {
+		api.control( 'page_for_posts', 'page_on_front', function( pageForPostsControl, pageOnFrontControl ) {
+			var onChangePageForPosts, onChangePageOnFront;
+
+			if ( ! api.ObjectSelectorControl ) {
+				return;
+			}
+			if ( ! ( pageForPostsControl.extended( api.ObjectSelectorControl ) || pageOnFrontControl.extended( api.ObjectSelectorControl ) ) ) {
+				return;
+			}
+
+			// Prevent page for posts from selecting the same page as page on front.
+			onChangePageOnFront = function( pageOnFront ) {
+				if ( pageOnFront ) {
+					pageForPostsControl.params.post_query_vars.post__not_in = [ pageOnFront ];
+					pageForPostsControl.params.post_query_vars.dropdown_args.exclude = [ pageOnFront ];
+				} else {
+					delete pageForPostsControl.params.post_query_vars.post__not_in;
+					delete pageForPostsControl.params.post_query_vars.dropdown_args.exclude;
+				}
+			};
+			pageOnFrontControl.setting.bind( onChangePageOnFront );
+			onChangePageOnFront( pageOnFrontControl.setting.get() );
+
+			// Prevent page on front from selecting the same page as page for posts.
+			onChangePageForPosts = function( pageForPosts ) {
+				if ( pageForPosts ) {
+					pageOnFrontControl.params.post_query_vars.post__not_in = [ pageForPosts ];
+					pageOnFrontControl.params.post_query_vars.dropdown_args.exclude = [ pageForPosts ];
+				} else {
+					delete pageOnFrontControl.params.post_query_vars.post__not_in;
+					delete pageOnFrontControl.params.post_query_vars.dropdown_args.exclude;
+				}
+			};
+			pageForPostsControl.setting.bind( onChangePageForPosts );
+			onChangePageForPosts( pageForPostsControl.setting.get() );
+		} );
+	} );
+
+})( wp.customize );

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -140,6 +140,12 @@ class Plugin {
 		$deps = array( 'customize-controls', 'customize-object-selector-component' );
 		$in_footer = 1;
 		$wp_scripts->add( $handle, $src, $deps, $this->version, $in_footer );
+
+		$handle = 'customize-object-selector-static-front-page';
+		$src = plugins_url( 'js/customize-object-selector-static-front-page' . $suffix, __DIR__ );
+		$deps = array( 'customize-object-selector-control' );
+		$in_footer = 1;
+		$wp_scripts->add( $handle, $src, $deps, $this->version, $in_footer );
 	}
 
 	/**
@@ -166,10 +172,18 @@ class Plugin {
 
 	/**
 	 * Enqueue controls scripts.
+	 *
+	 * @global \WP_Customize_Manager $wp_customize Manager.
 	 */
 	public function customize_controls_enqueue_scripts() {
+		global $wp_customize;
+
 		wp_enqueue_script( 'customize-object-selector-control' );
 		wp_enqueue_style( 'customize-object-selector-control' );
+
+		if ( $wp_customize->get_section( 'static_front_page' ) ) {
+			wp_enqueue_script( 'customize-object-selector-static-front-page' );
+		}
 	}
 
 	/**

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -44,7 +44,7 @@ class Plugin {
 		add_action( 'wp_default_styles', array( $this, 'register_styles' ), 100 );
 
 		add_action( 'customize_register', array( $this, 'register_control_type' ), 9 );
-		add_action( 'customize_register', array( $this, 'replace_dropdown_pages_controls' ), 11 );
+		add_action( 'customize_register', array( $this, 'replace_dropdown_pages_controls' ), 20 );
 
 		add_action( 'customize_controls_enqueue_scripts', array( $this, 'customize_controls_enqueue_scripts' ) );
 		add_action( 'customize_controls_print_footer_scripts', array( $this, 'print_templates' ) );
@@ -87,7 +87,7 @@ class Plugin {
 						'multiple' => false,
 						'allowClear' => true,
 						// @codingStandardsIgnoreStart
-						'placeholder' => __( '&mdash; Select &mdash;', 'default' ), // @todo WPCS's WordPress.WP.I18n.TextDomainMismatch sniff should allow default.
+						'placeholder' => __( '&mdash; Select &mdash;', 'default' ), // @todo WPCS's WordPress.WP.I18n.TextDomainMismatch sniff should allow default. See <https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/685>.
 						// @codingStandardsIgnoreEnd
 					),
 				) );


### PR DESCRIPTION
Improves the UX by eliminating the possibility an error scenario:

<img width="613" alt="reading_settings_ _wordpress_develops_ _wordpress" src="https://cloud.githubusercontent.com/assets/134745/18415818/78087a28-77b4-11e6-80ca-cd9d69013ee3.png">

Without object selector, a notification should be displayed when these are selected to be the same. Either that, or the `option` element should be disabled in one or the other if they are regular `dropdown-pages` controls. In any case, the object selector control short-circuits this from even being an issue:

<img width="299" alt="browsing for home" src="https://cloud.githubusercontent.com/assets/134745/18415832/3767bf5a-77b5-11e6-81ba-db70d17b1f32.png">

<img width="300" alt="searching for home" src="https://cloud.githubusercontent.com/assets/134745/18415840/5ac06308-77b5-11e6-8493-24f6d0e8d6dd.png">

In both these cases, the page “Home” is not listed in the selector for Page for Posts because it has already been selected as the Page on Front.

Short demo video: https://youtu.be/lDYN2cWczT8
