### PR TITLE
Increase z-index of section title.

### DIFF
--- a/css/customize-object-selector.css
+++ b/css/customize-object-selector.css
@@ -55,3 +55,8 @@
 .customize-object-selector-populating {
 	opacity: 0.5;
 }
+
+#customize-controls .customize-info.is-in-view,
+#customize-controls .customize-section-title.is-in-view {
+    z-index: 1000001; /* Because .select2-container has a z-index 1000000 */
+}


### PR DESCRIPTION
![overlapping](https://cloud.githubusercontent.com/assets/6297436/20097331/d884c882-a5d3-11e6-9b36-424dc74be2f8.png)
Since we have a very heigh z-index for select2 it overlaps with the sticky section title in 4.7 