### PR TITLE
Release 0.4.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "customize-object-selector",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "homepage": "https://github.com/xwp/wp-customize-object-selector",
   "authors": [
     "XWP"

--- a/customize-object-selector.php
+++ b/customize-object-selector.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Customize Object Selector
- * Version: 0.4.0
+ * Version: 0.4.1
  * Description: Adds a Customizer control to select posts (and eventually terms and users). Forked from Daniel Bachhuber's <a href="https://github.com/danielbachhuber/customizer-ajax-select">Customizer Ajax Select</a>.
  * Author: XWP
  * Plugin URI: https://github.com/xwp/wp-customize-object-selector

--- a/js/customize-object-selector-component.js
+++ b/js/customize-object-selector-component.js
@@ -47,7 +47,7 @@ wp.customize.ObjectSelectorComponent = (function( api, $ ) {
 		 * @param {Boolean}  args.show_add_buttons - Whether add buttons will be shown if available.
 		 * @returns {void}
 		 */
-		initialize: function initialize( args ) {
+		initialize: function initialize( args ) { // eslint-disable-line complexity
 			var component = this;
 
 			if ( ! args.model || 'function' !== typeof args.model.get ) {
@@ -429,8 +429,8 @@ wp.customize.ObjectSelectorComponent = (function( api, $ ) {
 			var component = this, editButton, onSelect;
 
 			editButton = component.container.find( '.select2-selection__choice__edit' );
-			onSelect = function( pageId ) {
-				pageId = parseInt( pageId, 10 );
+			onSelect = function( id ) {
+				var pageId = parseInt( id, 10 );
 				editButton.toggle( ! isNaN( pageId ) && 0 !== pageId && ! component.select2_options.multiple );
 			};
 			onSelect( component.model.get() );

--- a/js/customize-object-selector-component.js
+++ b/js/customize-object-selector-component.js
@@ -480,7 +480,7 @@ wp.customize.ObjectSelectorComponent = (function( api, $ ) {
 			selectedValues = component.getSelectedValues();
 			if ( ! refresh && _.isEqual( selectedValues, settingValues ) ) {
 				deferred.resolve();
-			} else if ( 0 === settingValues.length ) {
+			} else if ( 0 === settingValues.length || _.isEqual( [0], settingValues ) ) {
 				component.select.empty();
 				component.select.trigger( 'change' );
 				deferred.resolve();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "customize-object-selector",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -14,15 +14,15 @@
   },
   "homepage": "https://github.com/xwp/wp-customize-object-selector#readme",
   "devDependencies": {
-    "eslint": "^3.0.1",
+    "eslint": "^3.15.0",
     "grunt": "~0.4.5",
     "grunt-contrib-clean": "~1.0.0",
     "grunt-contrib-copy": "~1.0.0",
+    "grunt-contrib-cssmin": "^1.0.2",
     "grunt-contrib-jshint": "~1.0.0",
-    "grunt-contrib-cssmin": "~1.0.0",
     "grunt-contrib-uglify": "~1.0.0",
     "grunt-contrib-watch": "^1.0.0",
     "grunt-shell": "~1.3.0",
-    "grunt-wp-deploy": "^1.1.0"
+    "grunt-wp-deploy": "^1.2.1"
   }
 }

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -641,7 +641,7 @@ class Plugin {
 						$result['featured_image'] = null;
 					}
 				}
-				return $result;
+				return apply_filters( 'customize_object_selector_result', $result, $post, $post_query_args );
 			},
 			$query->posts
 		);

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -304,7 +304,7 @@ class Plugin {
 		);
 
 		// White list allowed meta query compare values.
-		$allowed_meta_query_compare_values = array( '=', '!=', '>', '>=', '<', '<=' );
+		$allowed_meta_query_compare_values = array( '=', '!=', '>', '>=', '<', '<=', 'LIKE' );
 
 		$original_post_query_vars = $post_query_vars;
 		$post_query_vars = wp_array_slice_assoc( $original_post_query_vars, $allowed_query_vars );

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -598,7 +598,7 @@ class Plugin {
 		$is_multiple_post_types = count( $query->get( 'post_type' ) ) > 1;
 
 		$results = array_map(
-			function( $post ) use ( $is_multiple_post_types, $post_query_args ) {
+			function( $post ) use ( $is_multiple_post_types, $post_query_args, $query ) {
 				$title = htmlspecialchars_decode( html_entity_decode( $post->post_title ), ENT_QUOTES );
 				$post_type_obj = get_post_type_object( $post->post_type );
 				$post_status_obj = get_post_status_object( $post->post_status );
@@ -641,7 +641,16 @@ class Plugin {
 						$result['featured_image'] = null;
 					}
 				}
-				return apply_filters( 'customize_object_selector_result', $result, $post, $post_query_args );
+
+				/**
+				 * Filters a result from querying posts for the customize object selector component.
+				 *
+				 * @param array     $result Result returned to Select2.
+				 * @param \WP_Post  $post   Post.
+				 * @param \WP_Query $query  Query.
+				 */
+				$result = apply_filters( 'customize_object_selector_result', $result, $post, $query );
+				return $result;
 			},
 			$query->posts
 		);

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -199,23 +199,32 @@ class Plugin {
 		global $wp_customize;
 
 		// Close output buffering to ensure that _ajax_wp_die_handler doesn't clobber the status_header(). See <https://core.trac.wordpress.org/ticket/35666#comment:6>.
-		while ( 0 !== ob_get_level()  ) {
+		while ( 0 !== ob_get_level() ) {
 			ob_end_clean();
 		}
 
 		$nonce_query_var_name = 'customize_object_selector_query_nonce';
 		if ( ! check_ajax_referer( static::OBJECT_SELECTOR_QUERY_AJAX_ACTION, $nonce_query_var_name, false ) ) {
 			status_header( 400 );
-			wp_send_json_error( array( 'code' => 'bad_nonce' ), 400 ); // Note: The redundant 400 status is needed until #35666 is resolved.
+			wp_send_json_error(
+				array(
+					'code' => 'bad_nonce',
+				),
+				400 // Note: The redundant 400 status is needed until #35666 is resolved.
+			);
 		}
 		if ( ! isset( $_POST['post_query_args'] ) ) {
 			status_header( 400 );
-			wp_send_json_error( array( 'code' => 'missing_post_query_args' ), 400 );
+			wp_send_json_error( array(
+				'code' => 'missing_post_query_args',
+			), 400 );
 		}
 		$post_query_args = json_decode( wp_unslash( $_POST['post_query_args'] ), true );
 		if ( ! is_array( $post_query_args ) ) {
 			status_header( 400 );
-			wp_send_json_error( array( 'code' => 'invalid_post_query_args' ), 400 );
+			wp_send_json_error( array(
+				'code' => 'invalid_post_query_args',
+			), 400 );
 		}
 
 		$post_query_args = $this->process_post_query_vars( $post_query_args );
@@ -322,14 +331,18 @@ class Plugin {
 			return new \WP_Error(
 				'disallowed_query_var',
 				__( 'Disallowed query var', 'customize-object-selector' ),
-				array( 'query_vars' => array_values( $extra_query_vars ) )
+				array(
+					'query_vars' => array_values( $extra_query_vars ),
+				)
 			);
 		}
 		if ( ! empty( $post_query_vars['meta_compare'] ) && ! in_array( $post_query_vars['meta_compare'], $allowed_meta_query_compare_values, true ) ) {
 			return new \WP_Error(
 				'disallowed_meta_compare_query_var',
 				__( 'Disallowed meta_compare query var', 'customize-object-selector' ),
-				array( 'query_var' => $post_query_vars['meta_compare'] )
+				array(
+					'query_var' => $post_query_vars['meta_compare'],
+				)
 			);
 		}
 
@@ -341,7 +354,9 @@ class Plugin {
 						return new \WP_Error(
 							'disallowed_meta_query_relation_var',
 							__( 'Disallowed meta_query relation', 'customize-object-selector' ),
-							array( 'query_vars' => array_values( $val ) )
+							array(
+								'query_vars' => array_values( $val ),
+							)
 						);
 					}
 					continue;
@@ -351,14 +366,18 @@ class Plugin {
 					return new \WP_Error(
 						'disallowed_meta_query_var',
 						__( 'Disallowed meta_query var', 'customize-object-selector' ),
-						array( 'query_vars' => array_values( $extra_meta_query_vars ) )
+						array(
+							'query_vars' => array_values( $extra_meta_query_vars ),
+						)
 					);
 				}
 				if ( ! empty( $val['compare'] ) && ! in_array( $val['compare'], $allowed_meta_query_compare_values, true ) ) {
 					return new \WP_Error(
 						'disallowed_meta_compare_query_var',
 						__( 'Disallowed meta_compare query var', 'customize-object-selector' ),
-						array( 'query_vars' => $post_query_vars['meta_query']['compare'] )
+						array(
+							'query_vars' => $post_query_vars['meta_query']['compare'],
+						)
 					);
 				}
 			}
@@ -379,7 +398,9 @@ class Plugin {
 				return new \WP_Error(
 					'bad_post_status',
 					__( 'Bad post status', 'customize-object-selector' ),
-					array( 'post_status' => $post_status )
+					array(
+						'post_status' => $post_status,
+					)
 				);
 			}
 			if ( ! empty( $post_status_object->publicly_queryable ) ) {
@@ -401,21 +422,27 @@ class Plugin {
 				return new \WP_Error(
 					'bad_post_type',
 					__( 'Bad post type', 'customize-object-selector' ),
-					array( 'post_type' => $post_type )
+					array(
+						'post_type' => $post_type,
+					)
 				);
 			}
 			if ( ! current_user_can( $post_type_object->cap->read ) ) {
 				return new \WP_Error(
 					'cannot_query_posts',
 					__( 'Cannot query posts', 'customize-object-selector' ),
-					array( 'post_type' => $post_type )
+					array(
+						'post_type' => $post_type,
+					)
 				);
 			}
 			if ( $has_private_status && ! current_user_can( $post_type_object->cap->read_private_posts ) ) {
 				return new \WP_Error(
 					'cannot_query_private_posts',
 					__( 'Cannot query private posts', 'customize-object-selector' ),
-					array( 'post_type' => $post_type )
+					array(
+						'post_type' => $post_type,
+					)
 				);
 			}
 		}
@@ -530,8 +557,11 @@ class Plugin {
 			if ( in_array( $key, $unsupported_args, true ) ) {
 				return new \WP_Error(
 					'unsupported_dropdown_pages_arg',
+					/* translators: placeholder is dropdown_pages argument */
 					sprintf( __( 'Unsupported arg "%s" in dropdown_args or supplied by page_attributes_dropdown_pages_args filter', 'customize-object-selector' ), $key ),
-					array( 'arg' => $key )
+					array(
+						'arg' => $key,
+					)
 				);
 			}
 		}

--- a/readme.md
+++ b/readme.md
@@ -7,8 +7,8 @@ Adds a Customizer control to select one or multiple posts (and eventually terms 
 **Contributors:** [xwp](https://profiles.wordpress.org/xwp), [westonruter](https://profiles.wordpress.org/westonruter)  
 **Tags:** [customizer](https://wordpress.org/plugins/tags/customizer), [customize](https://wordpress.org/plugins/tags/customize), [select2](https://wordpress.org/plugins/tags/select2), [posts](https://wordpress.org/plugins/tags/posts), [pages](https://wordpress.org/plugins/tags/pages), [dropdown](https://wordpress.org/plugins/tags/dropdown)  
 **Requires at least:** 4.5.0  
-**Tested up to:** 4.7.1  
-**Stable tag:** 0.4.0  
+**Tested up to:** 4.8.0-alpha  
+**Stable tag:** 0.4.1  
 **License:** [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)  
 
 [![Build Status](https://travis-ci.org/xwp/wp-customize-object-selector.svg?branch=master)](https://travis-ci.org/xwp/wp-customize-object-selector) [![Built with Grunt](https://cdn.gruntjs.com/builtwith.svg)](http://gruntjs.com) 
@@ -31,8 +31,15 @@ For an example integration with the Customize Posts plugin, see pending usage as
 
 ## Changelog ##
 
-### 0.4.1 - ? ###
+### 0.4.1 - 2017-02-17 ###
 * Increase importance of `z-index` in CSS rule for Select2 dropdown for compatibility with conflicting rule in Shortcake.
+* Fix bug with clearing a selection. See [#31](https://github.com/xwp/wp-customize-object-selector/pull/31)
+* Allow `LIKE` to be used in meta queries for object selector searches. See [#32](https://github.com/xwp/wp-customize-object-selector/pull/32)
+* Introduce `customize_object_selector_result` filter.
+
+See <a href="https://github.com/xwp/wp-customize-object-selector/milestone/2?closed=11">issues and PRs in milestone</a> and <a href="https://github.com/xwp/wp-customize-object-selector/compare/0.4.0...0.4.1">full release commit log</a>.
+
+Props Weston Ruter (<a href="https://github.com/westonruter" class="user-mention">@westonruter</a>), Sayed Taqui (<a href="https://github.com/sayedwp" class="user-mention">@sayedwp</a>.
 
 ### 0.4.0 - 2017-01-08 ###
 * Add an edit shortcut in selected posts to open corresponding post section from Customize Posts; re-use `wp.customize.Posts.startEditPostFlow()`. See [#8](https://github.com/xwp/wp-customize-object-selector/issues/8), PR [#12](https://github.com/xwp/wp-customize-object-selector/issues/12).

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors:      xwp, westonruter
 Tags:              customizer, customize, select2, posts, pages, dropdown
 Requires at least: 4.5.0
-Tested up to:      4.7.1
-Stable tag:        0.4.0
+Tested up to:      4.8.0-alpha
+Stable tag:        0.4.1
 License:           GPLv2 or later
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -27,9 +27,16 @@ For an example integration with the Customize Posts plugin, see pending usage as
 
 == Changelog ==
 
-= 0.4.1 - ? =
+= 0.4.1 - 2017-02-17 =
 
 * Increase importance of `z-index` in CSS rule for Select2 dropdown for compatibility with conflicting rule in Shortcake.
+* Fix bug with clearing a selection. See [#31](https://github.com/xwp/wp-customize-object-selector/pull/31)
+* Allow `LIKE` to be used in meta queries for object selector searches. See [#32](https://github.com/xwp/wp-customize-object-selector/pull/32)
+* Introduce `customize_object_selector_result` filter.
+
+See <a href="https://github.com/xwp/wp-customize-object-selector/milestone/2?closed=11">issues and PRs in milestone</a> and <a href="https://github.com/xwp/wp-customize-object-selector/compare/0.4.0...0.4.1">full release commit log</a>.
+
+Props Weston Ruter (<a href="https://github.com/westonruter" class="user-mention">@westonruter</a>), Sayed Taqui (<a href="https://github.com/sayedwp" class="user-mention">@sayedwp</a>.
 
 = 0.4.0 - 2017-01-08 =
 


### PR DESCRIPTION
- [x] Add contributor props.
- [x] Bump version numbers. `ack -Q 0.4.0` and replace with `0.4.1` where appropriate (this needs to be automated)
- [x] Add changelog to readme.
- [x] [Draft new GitHub release](https://github.com/xwp/wp-customize-object-selector/releases/new?tag=0.4.1) tag `0.4.1` on `master`, with ZIP build via `grunt build; cd build; zip -r ../customize-object-selector-0.4.1.zip *; cd -; cp customize-object-selector-0.4.1.zip ~/Downloads/customize-object-selector.zip`, and with link to readme on tag tree: https://github.com/xwp/wp-customize-object-selector/blob/0.4.1/readme.md#changelog
- [x] Test build.
- [x] Merge release PR.
- [x] Deploy to WordPress.org via `grunt deploy`. Remember to look at SVN diff.
- [x] Publish GitHub release.
- [x] Close GitHub milestone.


`pbpaste | sed "s/$PREV_NEW/$NEXT_NEW/g" | sed "s/$PREV_OLD/$PREV_NEW/g" | sed 's:\[x:\[ :'  | pbcopy`